### PR TITLE
KeyError quando um MerchantID/MerchantKey de formato correto mas não autorizado é usado

### DIFF
--- a/cieloApi3/request/base.py
+++ b/cieloApi3/request/base.py
@@ -36,13 +36,20 @@ class Base(object):
 
         response = s.send(prep)
 
-        if 'json' in response.headers['Content-Type'].lower():
+        try:
+            is_json = 'json' in response.headers['Content-Type'].lower()
+        except KeyError:
+            # Content type not in response.headers
+            is_json = False
+
+        if is_json:
             answers = response.json()
         else:
             answers = [{
                 'Code': str(response.status_code),
                 'Message': response.text
             }]
+
 
         if response.status_code >= 400:
             errors = []


### PR DESCRIPTION
O API da Cielo não responde JSON quando o request é não autorizado (HTTP 401). Isso resultava num KeyError na linha 39 de `cieloApi3/request/base.py`. Coloquei um try/except para resolver.